### PR TITLE
Add request throttling support with a default implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,33 @@ The YGOPRODeck API has rate limiting:
 - Exceeding this limit results in a **1-hour IP ban**
 - Cache responses locally to minimize API calls
 
+The **YgoApi client** automatically throttles requests to comply with the 20 requests/second limit. It uses a built-in queue system (`SignalBasedQueue`) that spaces out requests to avoid bans. Throttling behavior can be customized by providing a different interval or your own queue implementation via the `requestQueue` option and the `TimeQueue` interface.
+
+The default signal-based queue allows up to 20 requests to *start* per second, but does not wait for their completion before processing the next requests.
+
+### Custom Throttling
+
+```typescript
+import { YgoApi, SignalBasedQueue } from 'ygoapi'
+import type { TimeQueue } from 'ygoapi'
+
+const api = new YgoApi({
+  requestQueue: new SignalBasedQueue(1000) // 1000ms throttling between fetch starts
+})
+
+class MyQueue implements TimeQueue {
+  // The method needs to pass down the resolution of the task
+  enqueue<T>(task: () => Promise<T>, signal: AbortSignal): Promise<T> {
+    //... Your implementation ...
+  }
+  // ... Your implementation ...
+}
+
+const myApi = new YgoApi({
+  requestQueue: new MyQueue()
+})
+```
+
 ## Testing
 
 This library includes comprehensive test coverage with 53+ tests covering all features:

--- a/src/index.ts
+++ b/src/index.ts
@@ -671,7 +671,7 @@ export class YgoApi {
 	private readonly baseURL = 'https://db.ygoprodeck.com/api/v7'
 	private readonly headers: HeadersInit
 	private readonly cache?: KVStore
-	private readonly requestQueue?: TimeQueue
+	private readonly requestQueue: TimeQueue
 	private readonly cacheTtl: number
 	private readonly retryConfig: Required<RetryConfig>
 	private readonly fallbackConfig: Required<FallbackConfig>
@@ -684,7 +684,7 @@ export class YgoApi {
 			...options?.headers,
 		}
 		this.cache = options?.cache
-		this.requestQueue = options?.requestQueue
+		this.requestQueue = options?.requestQueue || new SignalBasedQueue(50) // Default to a 20 RPS queue
 		this.cacheTtl = options?.cacheTtl ?? 300000 // 5 minutes default
 		this.retryConfig = {
 			maxAttempts: options?.retry?.maxAttempts ?? 3,
@@ -887,13 +887,10 @@ export class YgoApi {
 							signal: controller.signal,
 						})
 
-					let response: Response
-
-					if (this.requestQueue) {
-						response = await this.requestQueue.enqueue(task, controller.signal)
-					} else {
-						response = await task()
-					}
+					const response = await this.requestQueue.enqueue(
+						task,
+						controller.signal,
+					)
 
 					clearTimeout(timeoutId)
 					const data = await response.json()
@@ -1248,6 +1245,168 @@ export class YgoApi {
 		if (this.imageCache instanceof FileSystemImageCache) {
 			await this.imageCache.cleanup()
 		}
+	}
+}
+
+// ============================================
+// Signal based Time Queue class
+// ============================================
+
+export class SignalBasedQueue implements TimeQueue {
+	/**
+	 * Array of AbortControllers representing queued tasks
+	 */
+	private readonly queue: AbortController[] = []
+	/**
+	 * Interval in milliseconds between task beginnings
+	 */
+	public readonly interval: number
+
+	/**
+	 * Flag indicating if the queue is currently being processed.
+	 * We use an AbortController to signal processing state to have a
+	 * signal that can be listened to for processing state changes.
+	 */
+	private _processing: AbortController | null = null
+	public get processing(): boolean {
+		return this._processing !== null && !this._processing.signal.aborted
+	}
+
+	/**
+	 * Creates an instance of the SignalBasedQueue.
+	 * @param interval Interval in milliseconds between task beginnings, default is 1000ms
+	 */
+	constructor(interval?: number) {
+		this.interval = interval || 1000
+	}
+
+	/**
+	 * Main loop that processes the signal based queue
+	 */
+	private async processQueue() {
+		// Abort if already processing
+		if (this.processing) return
+
+		// Loop through the queue until empty
+		this._processing = new AbortController()
+		while (this.queue.length > 0) {
+			const task = this.queue.shift()
+
+			if (task) {
+				// Signal the task is ready to be executed
+				task.abort()
+				// Wait for the defined interval before processing the next task
+				await new Promise((resolve) => setTimeout(resolve, this.interval))
+			}
+		}
+		this._processing?.abort()
+	}
+
+	/**
+	 * Enqueue a task to be executed
+	 * @param task The task to be executed, must return a Promise
+	 * @param signal Optional AbortSignal to cancel the task
+	 * @returns A Promise that resolves with the task's result or rejects if the task is aborted
+	 */
+	public enqueue<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+		return new Promise<T>((resolve, reject) => {
+			// Ensure the promise settles only once
+			let isSettled = false
+			const safeResolve = (value: T) => {
+				if (!isSettled) {
+					isSettled = true
+					resolve(value)
+				}
+			}
+			const safeReject = (error?: any) => {
+				if (!isSettled) {
+					isSettled = true
+					reject(error)
+				}
+			}
+
+			// If the provided signal is already aborted, reject immediately
+			if (signal?.aborted) {
+				safeReject(new DOMException('Aborted before enqueueing', 'AbortError'))
+				return
+			}
+
+			// We use an AbortController to signal when the task is ready to be executed
+			const readyController = new AbortController()
+
+			// Enqueue the task, represented by its controller
+			this.queue.push(readyController)
+
+			// Handler to dequeue the task if the provided signal is aborted, and reject the promise
+			const onAbort = () => {
+				const index = this.queue.indexOf(readyController)
+				if (index !== -1) {
+					this.queue.splice(index, 1)
+				}
+				safeReject(new DOMException('Aborted while enqueued', 'AbortError'))
+			}
+
+			// If an external signal is provided, listen for its abort event
+			if (signal) {
+				signal.addEventListener('abort', onAbort)
+			}
+			// Listening to the queue signaling the task is ready to be executed
+			readyController.signal.addEventListener('abort', () => {
+				// Clean up the abort listener, let the task handle its own abort if needed
+				if (signal) {
+					signal.removeEventListener('abort', onAbort)
+				}
+				// Execute the task
+				// Any resolution or rejections will be passed to the caller
+				task().then(safeResolve).catch(safeReject)
+			})
+
+			// Start processing the queue if not already doing so
+			if (!this.processing) {
+				this.processQueue()
+			}
+		})
+	}
+
+	/**
+	 * Helper method to await until the queue is done processing
+	 * @param timeoutMs Optional timeout in milliseconds. If provided, the promise will reject after this delay
+	 * @returns A Promise that resolves when the queue is done starting all tasks or rejects if timeout is reached
+	 */
+	public doneProcessing(timeoutMs?: number): Promise<void> {
+		return new Promise((resolve, reject) => {
+			// If not currently processing, resolve immediately
+			if (!this.processing) {
+				resolve()
+				return
+			}
+
+			let timeoutId: Timer | undefined
+
+			// Set up processing completion listener
+			const onProcessingDone = () => {
+				if (timeoutId) {
+					clearTimeout(timeoutId)
+				}
+				resolve()
+			}
+
+			// Set up timeout if provided
+			if (timeoutMs !== undefined && timeoutMs > 0) {
+				timeoutId = setTimeout(() => {
+					this._processing?.signal.removeEventListener(
+						'abort',
+						onProcessingDone,
+					)
+					reject(
+						new Error(`Queue still processing after ${timeoutMs}ms timeout`),
+					)
+				}, timeoutMs)
+			}
+
+			// Listen for processing completion
+			this._processing?.signal.addEventListener('abort', onProcessingDone)
+		})
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -719,7 +719,7 @@ export class YgoApi {
 	/**
 	 * Build query string from parameters
 	 */
-	private buildQueryString(params?: Record<string, any>): string {
+	private buildQueryString(params?: Record<string, unknown>): string {
 		if (!params) return ''
 
 		const query = new URLSearchParams()
@@ -750,7 +750,10 @@ export class YgoApi {
 	/**
 	 * Generate cache key from endpoint and parameters
 	 */
-	private getCacheKey(endpoint: string, params?: Record<string, any>): string {
+	private getCacheKey(
+		endpoint: string,
+		params?: Record<string, unknown>,
+	): string {
 		const sortedParams = params
 			? JSON.stringify(params, Object.keys(params).sort())
 			: ''
@@ -842,7 +845,7 @@ export class YgoApi {
 	 */
 	private async request<T>(
 		endpoint: string,
-		params?: Record<string, any>,
+		params?: Record<string, unknown>,
 	): Promise<T> {
 		// Validate offset/num parameters
 		if (
@@ -947,7 +950,13 @@ export class YgoApi {
 	 * @returns Card information response
 	 */
 	async getCardInfo(params?: CardInfoParams): Promise<CardInfoResponse> {
-		return this.request<CardInfoResponse>('/cardinfo.php', params)
+		// Type assertion to satisfy Record<string, unknown>
+		const sanitizedKeys: Record<string, unknown> = {}
+		if (params)
+			for (const [key, value] of Object.entries(params)) {
+				sanitizedKeys[key] = value
+			}
+		return this.request<CardInfoResponse>('/cardinfo.php', sanitizedKeys)
 	}
 
 	/**
@@ -1318,7 +1327,7 @@ export class SignalBasedQueue implements TimeQueue {
 					resolve(value)
 				}
 			}
-			const safeReject = (error?: any) => {
+			const safeReject = (error?: unknown) => {
 				if (!isSettled) {
 					isSettled = true
 					reject(error)

--- a/src/signalBasedQueue.test.ts
+++ b/src/signalBasedQueue.test.ts
@@ -29,7 +29,7 @@ describe('SignalBasedQueue', () => {
 
 		test('should return true when processing, false when available', async () => {
 			let taskStarted = false
-			let taskResolver: (value: string) => void
+			let taskResolver: (value: string) => void = () => {}
 
 			const task = () =>
 				new Promise<string>((resolve) => {
@@ -43,7 +43,7 @@ describe('SignalBasedQueue', () => {
 			expect(taskStarted).toBe(true)
 
 			// Complete the task
-			taskResolver!('completed')
+			taskResolver('completed')
 			await promise
 
 			// Wait for queue to be available again
@@ -431,7 +431,7 @@ describe('SignalBasedQueue', () => {
 			const results: Array<{
 				id: number
 				status: 'success' | 'error'
-				value?: any
+				value?: unknown
 			}> = []
 
 			const createTask = (id: number, shouldFail: boolean) => async () => {

--- a/src/signalBasedQueue.test.ts
+++ b/src/signalBasedQueue.test.ts
@@ -1,0 +1,619 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { SignalBasedQueue } from './index'
+
+describe('SignalBasedQueue', () => {
+	let queue: SignalBasedQueue
+
+	beforeEach(() => {
+		queue = new SignalBasedQueue(50) // 50ms interval for faster tests
+	})
+
+	describe('constructor', () => {
+		test('should create queue with default interval', () => {
+			const defaultQueue = new SignalBasedQueue()
+			expect(defaultQueue).toBeInstanceOf(SignalBasedQueue)
+			expect(defaultQueue.processing).toBe(false)
+		})
+
+		test('should create queue with custom interval', () => {
+			const customQueue = new SignalBasedQueue(100)
+			expect(customQueue).toBeInstanceOf(SignalBasedQueue)
+			expect(customQueue.processing).toBe(false)
+		})
+	})
+
+	describe('processing getter', () => {
+		test('should return false initially', () => {
+			expect(queue.processing).toBe(false)
+		})
+
+		test('should return true when processing, false when available', async () => {
+			let taskStarted = false
+			let taskResolver: (value: string) => void
+
+			const task = () =>
+				new Promise<string>((resolve) => {
+					taskStarted = true
+					taskResolver = resolve
+				})
+
+			const promise = queue.enqueue(task)
+
+			expect(queue.processing).toBe(true)
+			expect(taskStarted).toBe(true)
+
+			// Complete the task
+			taskResolver!('completed')
+			await promise
+
+			// Wait for queue to be available again
+			await new Promise((resolve) => setTimeout(resolve, queue.interval + 10))
+			expect(queue.processing).toBe(false)
+		})
+	})
+
+	describe('enqueue', () => {
+		test('should execute a simple task', async () => {
+			let executed = false
+			const task = async () => {
+				executed = true
+				return 'success'
+			}
+
+			const result = await queue.enqueue(task)
+
+			expect(executed).toBe(true)
+			expect(result).toBe('success')
+		})
+
+		test('should execute multiple tasks in sequence', async () => {
+			const executionOrder: number[] = []
+
+			const createTask = (id: number) => async () => {
+				executionOrder.push(id)
+				return `task-${id}`
+			}
+
+			const promises = [
+				queue.enqueue(createTask(1)),
+				queue.enqueue(createTask(2)),
+				queue.enqueue(createTask(3)),
+			]
+
+			const results = await Promise.all(promises)
+
+			expect(executionOrder).toEqual([1, 2, 3])
+			expect(results).toEqual(['task-1', 'task-2', 'task-3'])
+		})
+
+		test('should respect the interval between tasks', async () => {
+			const queue100ms = new SignalBasedQueue(100)
+			const timestamps: number[] = []
+
+			const createTask = (id: number) => async () => {
+				timestamps.push(Date.now())
+				return `task-${id}`
+			}
+
+			const promises = [
+				queue100ms.enqueue(createTask(1)),
+				queue100ms.enqueue(createTask(2)),
+				queue100ms.enqueue(createTask(3)),
+			]
+
+			await Promise.all(promises)
+
+			expect(timestamps.length).toBe(3)
+			// Check that there's roughly 100ms between each task start
+			expect(timestamps[1] - timestamps[0]).toBeGreaterThanOrEqual(90)
+			expect(timestamps[2] - timestamps[1]).toBeGreaterThanOrEqual(90)
+		})
+
+		test('should handle task that throws an error', async () => {
+			const task = async () => {
+				throw new Error('Task failed')
+			}
+
+			await expect(queue.enqueue(task)).rejects.toThrow('Task failed')
+		})
+
+		test('should handle async task that rejects', async () => {
+			const task = async () => {
+				await new Promise((resolve) => setTimeout(resolve, 10))
+				throw new Error('Async task failed')
+			}
+
+			await expect(queue.enqueue(task)).rejects.toThrow('Async task failed')
+		})
+
+		test('should handle tasks with different return types', async () => {
+			const stringTask = async () => 'string result'
+			const numberTask = async () => 42
+			const objectTask = async () => ({ key: 'value' })
+			const booleanTask = async () => true
+
+			const [strResult, numResult, objResult, boolResult] = await Promise.all([
+				queue.enqueue(stringTask),
+				queue.enqueue(numberTask),
+				queue.enqueue(objectTask),
+				queue.enqueue(booleanTask),
+			])
+
+			expect(strResult).toBe('string result')
+			expect(numResult).toBe(42)
+			expect(objResult).toEqual({ key: 'value' })
+			expect(boolResult).toBe(true)
+		})
+	})
+
+	describe('abort signal handling', () => {
+		test('should dequeue a task if aborted while queued', async () => {
+			const controller = new AbortController()
+			let taskExecuted = false
+
+			const task = async () => {
+				taskExecuted = true
+				return 'should not execute'
+			}
+
+			// Add a long-running task first to keep queue busy
+			const longTask = () =>
+				new Promise<string>((resolve) =>
+					setTimeout(() => resolve('long task'), 200),
+				)
+
+			const longPromise = queue.enqueue(longTask)
+			const abortPromise = queue.enqueue(task, controller.signal)
+
+			controller.abort() // Abort while queued
+
+			await expect(abortPromise).rejects.toThrow('Aborted while enqueued')
+			expect(taskExecuted).toBe(false)
+
+			// Long task should still complete
+			await expect(longPromise).resolves.toBe('long task')
+		})
+
+		test('should handle pre-aborted signal', async () => {
+			const controller = new AbortController()
+			controller.abort() // Abort before enqueueing
+
+			let taskExecuted = false
+			const task = async () => {
+				taskExecuted = true
+				return 'should not execute'
+			}
+
+			await expect(queue.enqueue(task, controller.signal)).rejects.toThrow(
+				'Aborted before enqueueing',
+			)
+			expect(taskExecuted).toBe(false)
+		})
+
+		test('should remove aborted task from queue', async () => {
+			const controller1 = new AbortController()
+			const controller2 = new AbortController()
+
+			let task1Executed = false
+			let task2Executed = false
+			let task3Executed = false
+
+			const task1 = async () => {
+				task1Executed = true
+				await new Promise((resolve) => setTimeout(resolve, 100))
+				return 'task1'
+			}
+
+			const task2 = async () => {
+				task2Executed = true
+				return 'task2'
+			}
+
+			const task3 = async () => {
+				task3Executed = true
+				return 'task3'
+			}
+
+			const promise1 = queue.enqueue(task1)
+			const promise2 = queue.enqueue(task2, controller1.signal)
+			const promise3 = queue.enqueue(task3, controller2.signal)
+
+			// Abort task2 while queued
+			setTimeout(() => controller1.abort(), 25)
+
+			const results = await Promise.allSettled([promise1, promise2, promise3])
+
+			expect(results[0].status).toBe('fulfilled')
+			expect(results[1].status).toBe('rejected')
+			expect(results[2].status).toBe('fulfilled')
+
+			expect(task1Executed).toBe(true)
+			expect(task2Executed).toBe(false)
+			expect(task3Executed).toBe(true)
+		})
+
+		test('should not abort task once it starts executing', async () => {
+			const controller = new AbortController()
+			let taskStarted = false
+			let taskCompleted = false
+
+			const task = async () => {
+				taskStarted = true
+				await new Promise((resolve) => setTimeout(resolve, 100))
+				taskCompleted = true
+				return 'completed'
+			}
+
+			const promise = queue.enqueue(task, controller.signal)
+
+			// Wait for task to start, then abort
+			await new Promise((resolve) => setTimeout(resolve, 25))
+			expect(taskStarted).toBe(true)
+			controller.abort()
+
+			// Task should still complete successfully
+			const result = await promise
+			expect(result).toBe('completed')
+			expect(taskCompleted).toBe(true)
+		})
+
+		test('should handle multiple aborts correctly', async () => {
+			const controllers = [
+				new AbortController(),
+				new AbortController(),
+				new AbortController(),
+			]
+
+			const executionOrder: number[] = []
+
+			const createTask = (id: number) => async () => {
+				executionOrder.push(id)
+				await new Promise((resolve) => setTimeout(resolve, 50))
+				return `task-${id}`
+			}
+
+			const promises = [
+				queue.enqueue(createTask(1), controllers[0].signal),
+				queue.enqueue(createTask(2), controllers[1].signal),
+				queue.enqueue(createTask(3), controllers[2].signal),
+			]
+
+			// Abort task 2 while queued
+			setTimeout(() => controllers[1].abort(), 25)
+
+			const results = await Promise.allSettled(promises)
+
+			expect(results[0].status).toBe('fulfilled')
+			expect(results[1].status).toBe('rejected')
+			expect(results[2].status).toBe('fulfilled')
+
+			expect(executionOrder).toEqual([1, 3]) // Task 2 was aborted
+		})
+	})
+
+	describe('doneProcessing', () => {
+		test('should resolve immediately when not processing', async () => {
+			const start = Date.now()
+			await queue.doneProcessing()
+			const elapsed = Date.now() - start
+
+			expect(elapsed).toBeLessThan(10) // Should be immediate
+		})
+
+		test('should wait for processing to complete', async () => {
+			let taskStarted = false
+			let taskCompleted = false
+
+			const dummyTask = async () => {}
+
+			const task = async () => {
+				taskStarted = true
+				await new Promise((resolve) => setTimeout(resolve, 200)) // Long running task
+				taskCompleted = true
+				return 'done'
+			}
+
+			queue.enqueue(dummyTask) // First task to start processing immediately
+			const taskPromise = queue.enqueue(task)
+			const donePromise = queue.doneProcessing()
+
+			expect(queue.processing).toBe(true)
+			expect(taskStarted).toBe(false)
+
+			await donePromise // Should resolve when queue processing is done (task started + interval passed)
+
+			// Queue should be done processing (ready to accept new tasks)
+			expect(queue.processing).toBe(false)
+			expect(taskStarted).toBe(true) // Task should have started
+			expect(taskCompleted).toBe(false) // But task itself is still running
+
+			// Wait for the actual task to complete
+			await taskPromise
+			expect(taskCompleted).toBe(true)
+		})
+
+		test('should handle timeout correctly', async () => {
+			let taskStarted = false
+
+			const task = async () => {
+				taskStarted = true
+				await new Promise((resolve) => setTimeout(resolve, 200))
+				return 'slow task'
+			}
+
+			const taskPromise = queue.enqueue(task)
+
+			// The queue should still be processing because it hasn't finished starting all tasks yet
+			await expect(queue.doneProcessing(10)).rejects.toThrow(
+				'Queue still processing after 10ms timeout',
+			)
+
+			// After timeout, queue should still be processing (hasn't finished the interval)
+			expect(queue.processing).toBe(true)
+
+			// Wait for queue processing to actually complete
+			await queue.doneProcessing()
+			expect(queue.processing).toBe(false)
+			expect(taskStarted).toBe(true)
+
+			// Wait for the actual task to complete
+			await taskPromise
+		})
+
+		test('should resolve before timeout if processing completes', async () => {
+			let taskStarted = false
+
+			const task = async () => {
+				taskStarted = true
+				await new Promise((resolve) => setTimeout(resolve, 200)) // Long running task
+				return 'quick task'
+			}
+
+			const taskPromise = queue.enqueue(task)
+			const start = Date.now()
+
+			await queue.doneProcessing(200) // Generous timeout
+
+			const elapsed = Date.now() - start
+			// Should complete when queue processing is done (task started + interval), not when task completes
+			expect(elapsed).toBeLessThan(150) // Should be around interval time (50ms) + some buffer
+			expect(queue.processing).toBe(false)
+			expect(taskStarted).toBe(true)
+
+			// Wait for actual task completion
+			await taskPromise
+		})
+
+		test('should handle multiple doneProcessing calls', async () => {
+			let taskStarted = false
+
+			const task = async () => {
+				taskStarted = true
+				await new Promise((resolve) => setTimeout(resolve, 200)) // Long running task
+				return 'task'
+			}
+
+			const taskPromise = queue.enqueue(task)
+
+			const donePromises = [
+				queue.doneProcessing(),
+				queue.doneProcessing(),
+				queue.doneProcessing(),
+			]
+
+			// All should resolve when queue processing is done (not when task completes)
+			await Promise.all(donePromises)
+
+			expect(queue.processing).toBe(false)
+			expect(taskStarted).toBe(true)
+
+			// Wait for actual task completion
+			await taskPromise
+		})
+
+		test('should clean up timeout on early completion', async () => {
+			const task = async () => {
+				await new Promise((resolve) => setTimeout(resolve, 50))
+				return 'task'
+			}
+
+			const taskPromise = queue.enqueue(task)
+
+			// This should not timeout since task completes in 50ms
+			await expect(queue.doneProcessing(200)).resolves.toBeUndefined()
+
+			await taskPromise
+		})
+	})
+
+	describe('complex scenarios', () => {
+		test('should handle mixed success and failure tasks', async () => {
+			const results: Array<{
+				id: number
+				status: 'success' | 'error'
+				value?: any
+			}> = []
+
+			const createTask = (id: number, shouldFail: boolean) => async () => {
+				await new Promise((resolve) => setTimeout(resolve, 20))
+				if (shouldFail) {
+					throw new Error(`Task ${id} failed`)
+				}
+				return `Task ${id} success`
+			}
+
+			const promises = [
+				queue.enqueue(createTask(1, false)).then(
+					(value) => results.push({ id: 1, status: 'success', value }),
+					(error) =>
+						results.push({ id: 1, status: 'error', value: error.message }),
+				),
+				queue.enqueue(createTask(2, true)).then(
+					(value) => results.push({ id: 2, status: 'success', value }),
+					(error) =>
+						results.push({ id: 2, status: 'error', value: error.message }),
+				),
+				queue.enqueue(createTask(3, false)).then(
+					(value) => results.push({ id: 3, status: 'success', value }),
+					(error) =>
+						results.push({ id: 3, status: 'error', value: error.message }),
+				),
+			]
+
+			await Promise.all(promises)
+
+			expect(results).toHaveLength(3)
+			expect(results[0]).toEqual({
+				id: 1,
+				status: 'success',
+				value: 'Task 1 success',
+			})
+			expect(results[1]).toEqual({
+				id: 2,
+				status: 'error',
+				value: 'Task 2 failed',
+			})
+			expect(results[2]).toEqual({
+				id: 3,
+				status: 'success',
+				value: 'Task 3 success',
+			})
+		})
+
+		test('should handle rapid enqueuing', async () => {
+			const executionOrder: number[] = []
+
+			const createTask = (id: number) => async () => {
+				executionOrder.push(id)
+				await new Promise((resolve) => setTimeout(resolve, 10))
+				return id
+			}
+
+			// Rapidly enqueue many tasks
+			const promises = Array.from({ length: 10 }, (_, i) =>
+				queue.enqueue(createTask(i + 1)),
+			)
+
+			const results = await Promise.all(promises)
+
+			expect(results).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+			expect(executionOrder).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+		})
+
+		test('should handle concurrent enqueue and abort operations', async () => {
+			const controllers: AbortController[] = []
+			const executionOrder: number[] = []
+
+			const createTask = (id: number) => async () => {
+				executionOrder.push(id)
+				await new Promise((resolve) => setTimeout(resolve, 30))
+				return id
+			}
+
+			// Create multiple tasks with abort controllers
+			const promises = Array.from({ length: 5 }, (_, i) => {
+				const controller = new AbortController()
+				controllers.push(controller)
+				return queue.enqueue(createTask(i + 1), controller.signal)
+			})
+
+			// Abort some tasks while they're queued
+			setTimeout(() => {
+				controllers[1].abort() // Abort task 2
+				controllers[3].abort() // Abort task 4
+			}, 25)
+
+			const results = await Promise.allSettled(promises)
+
+			// Tasks 1, 3, 5 should succeed; tasks 2, 4 should be aborted
+			expect(results[0].status).toBe('fulfilled')
+			expect(results[1].status).toBe('rejected')
+			expect(results[2].status).toBe('fulfilled')
+			expect(results[3].status).toBe('rejected')
+			expect(results[4].status).toBe('fulfilled')
+
+			expect(executionOrder).toEqual([1, 3, 5])
+		})
+
+		test('should maintain processing state correctly across multiple batches', async () => {
+			const batch1Tasks = Array.from({ length: 3 }, (_, i) => async () => {
+				await new Promise((resolve) => setTimeout(resolve, 30))
+				return `batch1-${i + 1}`
+			})
+
+			// Enqueue first batch
+			const batch1Promises = batch1Tasks.map((task) => queue.enqueue(task))
+
+			expect(queue.processing).toBe(true)
+
+			await Promise.all(batch1Promises)
+			await queue.doneProcessing()
+
+			expect(queue.processing).toBe(false)
+
+			// Enqueue second batch
+			const batch2Tasks = Array.from({ length: 2 }, (_, i) => async () => {
+				await new Promise((resolve) => setTimeout(resolve, 30))
+				return `batch2-${i + 1}`
+			})
+
+			const batch2Promises = batch2Tasks.map((task) => queue.enqueue(task))
+
+			expect(queue.processing).toBe(true)
+
+			await Promise.all(batch2Promises)
+			await queue.doneProcessing()
+
+			expect(queue.processing).toBe(false)
+		})
+	})
+
+	describe('edge cases', () => {
+		test('should handle empty queue gracefully', async () => {
+			expect(queue.processing).toBe(false)
+			await queue.doneProcessing()
+			expect(queue.processing).toBe(false)
+		})
+
+		test('should handle task that returns undefined', async () => {
+			const task = async (): Promise<undefined> => {
+				await new Promise((resolve) => setTimeout(resolve, 10))
+				return undefined
+			}
+
+			const result = await queue.enqueue(task)
+			expect(result).toBeUndefined()
+		})
+
+		test('should handle task that returns null', async () => {
+			const task = async () => {
+				await new Promise((resolve) => setTimeout(resolve, 10))
+				return null
+			}
+
+			const result = await queue.enqueue(task)
+			expect(result).toBeNull()
+		})
+
+		test('should handle synchronous tasks', async () => {
+			const task = async () => {
+				return 'immediate result'
+			}
+
+			const result = await queue.enqueue(task)
+			expect(result).toBe('immediate result')
+		})
+
+		test('should handle task with no return value', async () => {
+			let sideEffect = false
+			const task = async (): Promise<void> => {
+				await new Promise((resolve) => setTimeout(resolve, 10))
+				sideEffect = true
+			}
+
+			const result = await queue.enqueue(task)
+			expect(result).toBeUndefined()
+			expect(sideEffect).toBe(true)
+		})
+	})
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## **What**:

Added support for fetch request throttling to simplify handling the YGOPRODeck API rate limit, including a default implementation.

<!-- Why are these changes necessary? -->

## **Why**:

Implementing throttling within the client is necessary to exclude cache hits from the throttling logic.

<!-- How were these changes implemented? -->

## **How**:

### `TimeQueue` interface

Introduced a `TimeQueue` interface to describe a queue/throttler.  
The only required method is:

`enqueue<T>(task: () => Promise<T>, signal: AbortSignal): Promise<T>`

This method should delay the task if necessary, resolve with the task result, and be abortable via the provided signal.

- Updated the **YgoApi** constructor options to allow passing a `TimeQueue`.  
- Updated the `request` method of **YgoApi** to enqueue fetch tasks and await them instead of running instantly.  

### Default implementation: `SignalBasedQueue`

**TL;DR of the implementation:**
- When a task is enqueued, it stores an `AbortController` to signal when the task is ready to run. The task is then executed, and its resolution is returned.  
- A loop signals the next task at regular intervals.  
  *The interval is measured between fetch **starts**, not between one resolving and the next starting.*  
- Provides an asynchronous method that resolves when the queue is available.  

Added a test suite for the `SignalBasedQueue` implementation.

<!-- Have you done all of these things?  -->

## **Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation  
- [x] Tests  
- [x] Ready to be merged  
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
